### PR TITLE
Better Contrast on Selected Sidebar Rows

### DIFF
--- a/Material Spacegray Light.sublime-theme
+++ b/Material Spacegray Light.sublime-theme
@@ -562,7 +562,7 @@
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["selected"]}],
       "font.bold": false,
-      "color": [255, 255, 255]
+      "color": [128, 203, 196]
     },
 
     {
@@ -581,7 +581,7 @@
     {
       "class": "sidebar_label",
       "parents": [{"class": "tree_row", "attributes": ["expandable", "selected"]}],
-      "color": [255, 255, 255]
+      "color": [128, 203, 196]
     },
 
     {


### PR DESCRIPTION
Used a higher contrast color for selected sidebar rows in Material Spacegray Light theme
